### PR TITLE
Update create-release.yml due to new platforms variable introduced

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -183,12 +183,16 @@ jobs:
 
           exists_previous_stacks_filepath=$(git ls-tree --name-only "$latest_tag_or_commit" "$STACKS_FILEPATH")
 
-          if [[ -n $exists_previous_stacks_filepath ]]; then
-            git show "$latest_tag_or_commit:$STACKS_FILEPATH" >./previous_stacks.json
-            previous_platforms=$(jq -c '[.platforms[] | { name: sub("linux/"; "") , is_new: false }]' ./previous_stacks.json)
-          else
-            previous_platforms='[{"name": "amd64", "is_new": false}]'
-          fi
+          # Remove below line after a release
+          previous_platforms="$(jq -c '[.platforms[] | { name: sub("linux/"; "") , is_new: true }]' $STACKS_FILEPATH )"
+
+          # Uncomment below code after a release
+          # if [[ -n $exists_previous_stacks_filepath ]]; then
+          #   git show "$latest_tag_or_commit:$STACKS_FILEPATH" >./previous_stacks.json
+          #   previous_platforms=$(jq -c '[.platforms[] | { name: sub("linux/"; "") , is_new: false }]' ./previous_stacks.json)
+          # else
+          #   previous_platforms='[{"name": "amd64", "is_new": false}]'
+          # fi
 
           platforms=$(echo "$current_platforms" | jq -c --argjson prev "$previous_platforms" '
               map(


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This is a temp PR that will get reverted. Due to on a previous commit there is no variable on the images.json called platforms, the workflow fails to iterate on it. For that reason we skip this step by setting the previous platforms to the current ones, as new platform has been introduced. After having a release, we will revert this code back to its normal version. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
